### PR TITLE
Examples/Common.c : remove check for Vulkan, delegate to SDL_ShaderCross_CompileFromSPIRV(), update README

### DIFF
--- a/Examples/Common.c
+++ b/Examples/Common.c
@@ -95,14 +95,7 @@ SDL_GPUShader* LoadShader(
 		.num_storage_buffers = storageBufferCount,
 		.num_storage_textures = storageTextureCount
 	};
-	if (SDL_GetGPUDriver(device) == SDL_GPU_DRIVER_VULKAN)
-	{
-		shader = SDL_CreateGPUShader(device, &shaderInfo);
-	}
-	else
-	{
-		shader = SDL_ShaderCross_CompileFromSPIRV(device, &shaderInfo, SDL_FALSE);
-	}
+	shader = SDL_ShaderCross_CompileFromSPIRV(device, &shaderInfo, SDL_FALSE);
 	if (shader == NULL)
 	{
 		SDL_Log("Failed to create shader!");

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 WIP collection of examples to demonstrate the usage of the SDL_gpu proposal.
 
 To clone and build:
-```
+
+```bash
 git clone https://github.com/thatcosmonaut/SDL -b gpu
 cd SDL
 mkdir build
@@ -15,4 +16,9 @@ mkdir build
 cd build
 cmake .. -DSDL3_DIR="full/path/to/SDL/build"
 ```
+
 then run `make` or your favorite IDE.
+
+## Dependencies
+
+On non-Vulkan platforms the SPIR-V shaders need to be converted using [spirv-cross](https://github.com/KhronosGroup/SPIRV-Cross), specifically `libspirv-cross-c-shared`. It needs to be installed at the system level or just on your `LD_LIBRARY_PATH` (on Unix).


### PR DESCRIPTION
A minor simplification: no need to call SDL_CreateGPUShader ourselves, SDL_ShaderCross_CompileFromSPIRV does it for us.

I also update the README to tell users they need to have `libspirv-cross-c-shared` installed.