### PR TITLE
Rename value in SDL_GPUSwapchainComposition enum

### DIFF
--- a/Examples/ToneMapping.c
+++ b/Examples/ToneMapping.c
@@ -11,14 +11,14 @@ static SDL_GPUSwapchainComposition swapchainCompositions[] =
 	SDL_GPU_SWAPCHAINCOMPOSITION_SDR,
 	SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR,
 	SDL_GPU_SWAPCHAINCOMPOSITION_HDR_EXTENDED_LINEAR,
-	SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2048
+	SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2084
 };
 static const char* swapchainCompositionNames[] =
 {
 	"SDL_GPU_SWAPCHAINCOMPOSITION_SDR",
 	"SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR",
 	"SDL_GPU_SWAPCHAINCOMPOSITION_HDR_EXTENDED_LINEAR",
-	"SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2048"
+	"SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2084"
 };
 static Sint32 swapchainCompositionCount = sizeof(swapchainCompositions)/sizeof(SDL_GPUSwapchainComposition);
 static Sint32 swapchainCompositionSelectionIndex = 0;
@@ -285,7 +285,7 @@ static int Draw(Context* context)
 		/* Transfer to target color space if necessary */
 		if (
 			currentSwapchainComposition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR ||
-			currentSwapchainComposition == SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2048
+			currentSwapchainComposition == SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2084
 		) {
 			computePass = SDL_BeginGPUComputePass(
 				cmdbuf,


### PR DESCRIPTION
The latest version of SDL3 includes [PR #11719](https://github.com/libsdl-org/SDL/pull/11719), which renames `SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2048` to `SDL_GPU_SWAPCHAINCOMPOSITION_HDR10_ST2084` in `enum SDL_GPUSwapchainComposition`.