### PR TITLE
Crash Fix for CompressedTextures.c

### DIFF
--- a/Examples/CompressedTextures.c
+++ b/Examples/CompressedTextures.c
@@ -319,7 +319,7 @@ static int Draw(Context* context)
 					.source.w = 256,
 					.source.h = 256,
 					.destination.texture = swapchainTexture,
-					.destination.x = 512,
+					.destination.x = 384,
 					.destination.w = 256,
 					.destination.h = 256,
 				}


### PR DESCRIPTION
The second blit in Draw tries to copy to memory outside the right edge. This results in a VK_ERROR_DEVICE_LOST. 