### PR TITLE
Add shadercross compile.bat

### DIFF
--- a/Content/Shaders/Source/compile.bat
+++ b/Content/Shaders/Source/compile.bat
@@ -1,0 +1,27 @@
+rem Requires shadercross CLI installed from SDL_shadercross
+@echo off
+setlocal enabledelayedexpansion
+
+for %%f in (*.vert.hlsl) do (
+    if exist "%%f" (
+        shadercross "%%f" -o "..\Compiled\SPIRV\%%~nf.spv"
+        shadercross "%%f" -o "..\Compiled\MSL\%%~nf.msl"
+        shadercross "%%f" -o "..\Compiled\DXIL\%%~nf.dxil"
+    )
+)
+
+for %%f in (*.frag.hlsl) do (
+    if exist "%%f" (
+        shadercross "%%f" -o "..\Compiled\SPIRV\%%~nf.spv"
+        shadercross "%%f" -o "..\Compiled\MSL\%%~nf.msl"
+        shadercross "%%f" -o "..\Compiled\DXIL\%%~nf.dxil"
+    )
+)
+
+for %%f in (*.comp.hlsl) do (
+    if exist "%%f" (
+        shadercross "%%f" -o "..\Compiled\SPIRV\%%~nf.spv"
+        shadercross "%%f" -o "..\Compiled\MSL\%%~nf.msl"
+        shadercross "%%f" -o "..\Compiled\DXIL\%%~nf.dxil"
+    )
+)

--- a/Content/Shaders/Source/compile.bat
+++ b/Content/Shaders/Source/compile.bat
@@ -1,4 +1,4 @@
-rem Requires shadercross CLI installed from SDL_shadercross
+:: Requires shadercross CLI installed from SDL_shadercross
 @echo off
 setlocal enabledelayedexpansion
 


### PR DESCRIPTION
This is a trivial but helpful addition: a shader cross compilation batch file for Windows users.