### PR TITLE
Added support for building SDL3 from source when we fail find_package 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 .vscode/
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,19 @@
 cmake_minimum_required(VERSION 3.10)
 project(SDL_gpu_examples)
-find_package(SDL3 REQUIRED)
+find_package(SDL3 CONFIG QUIET)
+
+if(NOT SDL3_FOUND)
+    message(STATUS "SDL3 not found. Building it from source.")
+    include(FetchContent)
+    FetchContent_Declare(
+            SDL
+            GIT_REPOSITORY https://github.com/libsdl-org/SDL
+            GIT_TAG        "release-3.2.16"
+    )
+    FetchContent_MakeAvailable(SDL)
+else()
+    find_package(SDL3 REQUIRED)
+endif()
 
 add_executable(SDL_gpu_examples
     Examples/main.c


### PR DESCRIPTION
=== INFO ===

When running aarch64 bookworm for the Raspberry Pi 5 we fail to build this project as SDL3 is not distributed

To address this I've pulled in a snippet from the SDL3 CMake example which builds SDL from source when it fails find_package

I've set the git tag to the most recent release: `release-3.2.16`

=== CODE ===

/CMakeList.txt
- Added fallback code which builds SDL3 from source when it fails find_package

/.gitignore
- Added .idea/ to the ignore list, this folder is used by JetBrains products / CLion