### PR TITLE
Portable alternative to StructuredBuffer<T>

### DIFF
--- a/Content/Shaders/Source/PullSpriteBatch.vert.hlsl
+++ b/Content/Shaders/Source/PullSpriteBatch.vert.hlsl
@@ -19,7 +19,7 @@ struct Output
 // They will work with SDL_shadercross because it does special processing to
 // support them, but not with direct compilation via dxc.
 // See https://github.com/libsdl-org/SDL/issues/12200 for details.
-StructuredBuffer<SpriteData> DataBuffer : register(t0, space0);
+ByteAddressBuffer DataBuffer : register(t0, space0);
 
 cbuffer UniformBlock : register(b0, space1)
 {
@@ -38,7 +38,7 @@ Output main(uint id : SV_VertexID)
 {
     uint spriteIndex = id / 6;
     uint vert = triangleIndices[id % 6];
-    SpriteData sprite = DataBuffer[spriteIndex];
+    SpriteData sprite = DataBuffer.Load<SpriteData>(spriteIndex * sizeof(SpriteData));
 
     float2 texcoord[4] = {
         {sprite.TexU,               sprite.TexV              },


### PR DESCRIPTION
Hello!

This change addresses https://github.com/libsdl-org/SDL/issues/12200.
Similar to how **spirv-cross** and **shadercross** handle this case, it converts
`StructuredBuffer<T>` into `ByteAddressBuffer` to avoid the `StructureByteStride = 0`
issue.

I tested this approach in my own renderer project and confirmed that it works correctly.
This solution is also more readable compared to the output from spirv-cross.

The corresponding comment needs to be updated to reflect these changes.