### PR TITLE
README: Add a missing make command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ cd SDL
 mkdir build
 cd build
 cmake ..
+make
 
 cd ../..
 git clone https://github.com/TheSpydog/SDL_gpu_examples


### PR DESCRIPTION
Without this it was not clear if make will get executed automatically or not (it does not), so one has to execute it by hand, which this PR makes clear.