### PR TITLE
Update SDL to v3.4.12 to fix compile errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT SDL3_FOUND)
     FetchContent_Declare(
             SDL
             GIT_REPOSITORY https://github.com/libsdl-org/SDL
-            GIT_TAG        "release-3.2.16"
+            GIT_TAG        "release-3.4.12"
     )
     FetchContent_MakeAvailable(SDL)
 else()


### PR DESCRIPTION
SDL 3.2.18 provided by the current FetchContent lacks a layer property in SDL_GPUDepthStencilTargetInfo

Updating to the latest release of 3.4.12 resolves this as the property has been added